### PR TITLE
[fix]tokenを返す際の参照先修正

### DIFF
--- a/opt/chat/views.py
+++ b/opt/chat/views.py
@@ -181,6 +181,6 @@ def obtain_room_msg(request, room_id):
             "name": all_message_query[0].room.name,
         },
         "messages": messages,
-        "token": token
+        "token": request.auth
     }
     return JsonResponse(res, status=200)


### PR DESCRIPTION
# 目的
tokenを返す際のエラーの修正

# 概要
- ルームメッセージ取得apiのresponseで未定義の`token`を返していたが、tokenが入っている`request.auth`を返すように修正した